### PR TITLE
Add missing CI build flags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         run: dotnet --info
 
       - name: Build
-        run: dotnet build -c release
+        run: dotnet build -c release /p:ContinuousIntegrationBuild=true
 
       - name: Create release
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/LockCheck.Tests/LockCheck.Tests.csproj
+++ b/LockCheck.Tests/LockCheck.Tests.csproj
@@ -7,10 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LockCheck/LockCheck.csproj
+++ b/LockCheck/LockCheck.csproj
@@ -26,6 +26,10 @@
     <NoWarn>$(NoWarn);CA1031;CA1303;CA1801;CA1716;NU5105;CA1416</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />

--- a/LockCheck/LockCheck.csproj
+++ b/LockCheck/LockCheck.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION


To fix these: https://nuget.info/packages/LockChecker/0.9.32-ga5882a952b

![image](https://github.com/domsleee/LockCheck/assets/14891742/c8586388-df8e-4988-b904-865e0495bbcf)
